### PR TITLE
auth dialog: allow to override url loading

### DIFF
--- a/library/src/main/java/com/wuman/android/auth/AuthorizationDialogController.java
+++ b/library/src/main/java/com/wuman/android/auth/AuthorizationDialogController.java
@@ -93,4 +93,12 @@ public interface AuthorizationDialogController extends AuthorizationUIController
      */
     boolean removePreviousCookie();
 
+    /**
+     * Indicate whether the webclient associated to the web view should override
+     * the loading of an URL.
+     *
+     * @return {@code true} if the URL loading is overriden, {@code false}
+     *         otherwise.
+     */
+    boolean shouldOverrideUrlLoading(WebView view, String url);
 }

--- a/library/src/main/java/com/wuman/android/auth/DialogFragmentController.java
+++ b/library/src/main/java/com/wuman/android/auth/DialogFragmentController.java
@@ -9,6 +9,7 @@ import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.WebView;
 
 import com.google.api.client.auth.oauth.OAuthAuthorizeTemporaryTokenUrl;
 import com.google.api.client.auth.oauth2.AuthorizationCodeRequestUrl;
@@ -299,4 +300,8 @@ public abstract class DialogFragmentController implements AuthorizationDialogCon
         return false;
     }
 
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, String url) {
+        return false;
+    }
 }

--- a/library/src/main/java/com/wuman/android/auth/OAuthDialogFragment.java
+++ b/library/src/main/java/com/wuman/android/auth/OAuthDialogFragment.java
@@ -313,6 +313,7 @@ class OAuthDialogFragment extends DialogFragmentCompat {
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
                 LOGGER.info("shouldOverrideUrlLoading: " + url);
+                if (mController.shouldOverrideUrlLoading(view, url)) return true;
                 interceptUrlCompat(view, url, true);
                 return true;
             }


### PR DESCRIPTION
As the web view is set in the OAuthDialogFragment, there is no way to
override url loading with the existing interface. The
AuthorizationDialogController interface has then be extended so that
people can change the default behaviour.
